### PR TITLE
Feat WorkHandler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,138 @@
 version = 3
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
 name = "plx"
 version = "0.1.2"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2021"
 exclude = ["*.md"]
 
 [dependencies]
+rand = "0.8.5"

--- a/src/core.rs
+++ b/src/core.rs
@@ -2,3 +2,4 @@ pub mod core;
 pub mod editor;
 pub mod file_utils;
 pub mod process;
+pub mod work;

--- a/src/core/core.rs
+++ b/src/core/core.rs
@@ -1,9 +1,17 @@
-use crate::models::{project::Project, ui_state::UiState};
+use std::sync::mpsc::{self, Receiver, Sender};
 
-use super::file_utils::file_handler;
+use crate::models::{event::Event, exo::Exo, project::Project, ui_state::UiState};
+
+use super::{
+    editor::opener::EditorOpener,
+    file_utils::file_handler,
+    work::{work::Work, work_handler::WorkHandler},
+};
 pub struct PlxCore<'a> {
     ui_state: UiState<'a>,
     project: Project,
+    work_handler: WorkHandler,
+    event_queue: (Sender<Event>, Receiver<Event>),
 }
 
 impl PlxCore<'_> {
@@ -14,9 +22,12 @@ impl PlxCore<'_> {
         let project_file = file_handler::project_file();
         let project = Project::try_from(project_file);
         if let Ok(project) = project {
+            let channel = mpsc::channel();
             Some(PlxCore {
                 ui_state: UiState::Home,
                 project,
+                work_handler: WorkHandler::new(channel.0.clone()),
+                event_queue: channel,
             })
         } else {
             None
@@ -24,5 +35,12 @@ impl PlxCore<'_> {
     }
     pub fn get_state(&self) -> &UiState {
         &self.ui_state
+    }
+    fn open_editor(&mut self, exo: &Exo) {
+        if let Some(file) = exo.get_main_file() {
+            if let Some(opener) = EditorOpener::new_default_editor(file.to_path_buf()) {
+                self.work_handler.spawn_worker(Work::EditorOpen(opener));
+            }
+        }
     }
 }

--- a/src/core/editor/opener.rs
+++ b/src/core/editor/opener.rs
@@ -1,7 +1,6 @@
 use std::{
     path,
     sync::{atomic::AtomicBool, mpsc::Sender, Arc},
-    thread::{self},
 };
 
 use crate::{
@@ -9,18 +8,32 @@ use crate::{
     models::event::Event,
 };
 
-pub enum WorkerEvent {
-    StopWork,
-}
+use super::editor::get_default_editor;
 
-pub fn run(
-    tx: Sender<Event>,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EditorOpener {
     editor: String,
     file_path: path::PathBuf,
-    should_stop: Arc<AtomicBool>,
-) {
-    Some(thread::spawn(move || loop {
-        let child = process_handler::spawn_process(&editor, vec![file_path.display().to_string()]);
+}
+
+impl EditorOpener {
+    pub fn new(editor: String, file_path: path::PathBuf) -> Self {
+        EditorOpener { editor, file_path }
+    }
+
+    pub fn new_default_editor(file_path: path::PathBuf) -> Option<Self> {
+        match get_default_editor() {
+            Some(editor) => Some(EditorOpener::new(editor, file_path)),
+            None => None,
+        }
+    }
+}
+impl EditorOpener {
+    pub fn run(&self, tx: Sender<Event>, should_stop: Arc<AtomicBool>) {
+        let child = process_handler::spawn_process(
+            &self.editor,
+            vec![self.file_path.display().to_string()],
+        );
         let _ = match child {
             Ok(mut child) => match wait_child(&mut child, should_stop.clone()) {
                 Ok(_) => tx.send(Event::EditorOpened),
@@ -28,24 +41,20 @@ pub fn run(
             },
             Err(_) => tx.send(Event::CouldNotOpenEditor),
         };
-    }));
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{str::FromStr, sync::mpsc};
+    use std::sync::mpsc;
 
     #[test]
     fn opens_file() {
         let (tx, rx) = mpsc::channel();
         let should_stop = Arc::new(AtomicBool::new(false));
-        run(
-            tx.clone(),
-            "echo".to_string(),
-            path::PathBuf::from_str("./opener.rs").unwrap(),
-            should_stop.clone(),
-        );
+        let worker = EditorOpener::new("echo".to_string(), ".opener.rs".into());
+        worker.run(tx.clone(), should_stop.clone());
         assert_eq!(rx.recv().unwrap(), Event::EditorOpened);
     }
 
@@ -53,12 +62,8 @@ mod tests {
     fn opens_file_missing_editor() {
         let (tx, rx) = mpsc::channel();
         let should_stop = Arc::new(AtomicBool::new(false));
-        run(
-            tx.clone(),
-            "_".to_string(),
-            path::PathBuf::from_str("./opener.rs").unwrap(),
-            should_stop.clone(),
-        );
+        let worker = EditorOpener::new("_".to_string(), ".opener.rs".into());
+        worker.run(tx.clone(), should_stop.clone());
         assert_eq!(rx.recv().unwrap(), Event::CouldNotOpenEditor);
     }
 }

--- a/src/core/work.rs
+++ b/src/core/work.rs
@@ -1,0 +1,3 @@
+pub mod work;
+pub mod work_handler;
+pub mod worker;

--- a/src/core/work/work.rs
+++ b/src/core/work/work.rs
@@ -1,0 +1,6 @@
+use crate::core::editor::opener::EditorOpener;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Work {
+    EditorOpen(EditorOpener),
+}

--- a/src/core/work/work_handler.rs
+++ b/src/core/work/work_handler.rs
@@ -1,20 +1,63 @@
-use std::{collections::HashMap, sync::mpsc::Sender};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, Sender},
+        Arc, Mutex,
+    },
+    thread::{self, JoinHandle},
+};
 
 use crate::models::event::Event;
 
 use super::{work::Work, worker::Worker};
 
-pub struct WorkHandler {
-    workers: HashMap<usize, Worker>,
-    tx: Sender<Event>,
+pub(crate) enum WorkEvent {
+    Done(usize),
+    Stop(usize),
 }
-impl WorkHandler {
-    pub fn new(tx: Sender<Event>) -> Self {
-        WorkHandler {
-            workers: HashMap::new(),
-            tx,
+struct WorkInfo {
+    work: Work,
+    should_stop: Arc<AtomicBool>,
+    join_handle: JoinHandle<()>,
+}
+
+pub struct WorkHandler {
+    workers: HashMap<usize, WorkInfo>,
+    tx: Sender<Event>,
+    work_tx: Sender<WorkEvent>,
+}
+impl WorkInfo {
+    fn new(work: Work, should_stop: Arc<AtomicBool>, join_handle: JoinHandle<()>) -> Self {
+        WorkInfo {
+            work,
+            should_stop,
+            join_handle,
         }
     }
+    fn stop(&mut self) {
+        self.should_stop.store(true, Ordering::Relaxed);
+    }
+    fn join(self) {
+        self.join_handle.join();
+    }
+    fn stop_and_join(mut self) {
+        self.stop();
+        self.join();
+    }
+}
+impl WorkHandler {
+    pub fn new(tx: Sender<Event>) -> Arc<Mutex<Self>> {
+        let (work_tx, rx) = mpsc::channel();
+        let ret = Arc::new(Mutex::new(WorkHandler {
+            workers: HashMap::new(),
+            tx,
+            work_tx,
+        }));
+        WorkHandler::run(ret.clone(), rx);
+        ret
+    }
+
     fn spawn_id(&self) -> usize {
         loop {
             let id = rand::random::<usize>();
@@ -25,30 +68,54 @@ impl WorkHandler {
     }
     pub fn spawn_worker(&mut self, work_type: Work) -> usize {
         let id = self.spawn_id();
-        let mut worker = Worker::new(self.tx.clone(), work_type);
-        worker.run();
-        self.workers.insert(id, worker);
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker = Worker::new(
+            id,
+            self.work_tx.clone(),
+            self.tx.clone(),
+            stop.clone(),
+            work_type.clone(),
+        );
+        let join_handle = worker.run();
+        self.workers
+            .insert(id, WorkInfo::new(work_type, stop, join_handle));
         id
     }
+
+    fn run(handler: Arc<Mutex<WorkHandler>>, rx: Receiver<WorkEvent>) {
+        thread::spawn(move || {
+            while let Ok(msg) = rx.recv() {
+                if let Ok(mut handler) = handler.lock() {
+                    match msg {
+                        WorkEvent::Done(id) => handler.remove_worker(id),
+                        WorkEvent::Stop(id) => handler.stop_worker(id),
+                    }
+                };
+            }
+        });
+    }
+
     pub fn stop_worker(&mut self, id: usize) {
         match self.workers.remove(&id) {
-            Some(mut worker) => worker.stop(),
+            Some(worker) => worker.stop_and_join(),
             None => (),
         }
     }
     pub fn stop_workers(&mut self, work_type: Work) {
         self.workers
             .iter_mut()
-            .filter(|(_, worker)| worker.work_type == work_type)
+            .filter(|(_, worker)| worker.work == work_type)
             .for_each(|(_, worker)| worker.stop());
-        self.workers
-            .retain(|_, worker| worker.work_type != work_type);
+        self.workers.retain(|_, worker| worker.work != work_type);
     }
     pub fn stop_all_workers(&mut self) {
         self.workers
             .iter_mut()
             .for_each(|(_, worker)| worker.stop());
         self.workers.clear();
+    }
+    fn remove_worker(&mut self, id: usize) {
+        self.workers.remove(&id);
     }
 }
 #[cfg(test)]
@@ -60,64 +127,85 @@ mod tests {
     #[test]
     fn test_different_ids() {
         let (tx, _) = channel();
-        let mut handler = WorkHandler::new(tx.clone());
+        let handler = WorkHandler::new(tx.clone());
         let mut last_id: Option<usize> = None;
         for _ in 0..10 {
-            let id = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
-                "echo".to_string(),
-                "null".into(),
-            )));
-            if last_id.is_none() {
-                last_id = Some(id);
-            } else {
-                assert_ne!(last_id.unwrap(), id);
+            if let Ok(mut handler) = handler.lock() {
+                let id = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
+                    "echo".to_string(),
+                    "null".into(),
+                )));
+                if last_id.is_none() {
+                    last_id = Some(id);
+                } else {
+                    assert_ne!(last_id.unwrap(), id);
+                }
             }
         }
     }
     #[test]
     fn test_spawn_worker() {
         let (tx, _) = channel();
-        let mut handler = WorkHandler::new(tx.clone());
+        let handler = WorkHandler::new(tx.clone());
 
-        let id = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
-            "echo".to_string(),
-            "null".into(),
-        )));
-        assert!(handler.workers.contains_key(&id));
-        matches!(
-            handler.workers.get(&id).unwrap().work_type,
-            Work::EditorOpen(_)
-        );
+        if let Ok(mut handler) = handler.lock() {
+            let id = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
+                "echo".to_string(),
+                "null".into(),
+            )));
+
+            assert!(handler.workers.contains_key(&id));
+            assert!(!handler
+                .workers
+                .get(&id)
+                .unwrap()
+                .should_stop
+                .load(Ordering::Relaxed));
+            matches!(handler.workers.get(&id).unwrap().work, Work::EditorOpen(_));
+        };
     }
     #[test]
     fn test_stop_worker() {
         let (tx, _) = channel();
-        let mut handler = WorkHandler::new(tx.clone());
+        let handler = WorkHandler::new(tx.clone());
 
-        let id = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
-            "echo".to_string(),
-            "null".into(),
-        )));
-        //Can't actually check this calls worker.stop() unless worker becomes a trait
-        handler.stop_worker(id);
-        assert!(!handler.workers.contains_key(&id));
+        if let Ok(mut handler) = handler.lock() {
+            let id = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
+                "echo".to_string(),
+                "null".into(),
+            )));
+            let stop = handler.workers.get(&id).unwrap().should_stop.clone();
+            handler.stop_worker(id);
+            assert!(!handler.workers.contains_key(&id));
+            assert!(stop.load(Ordering::Relaxed));
+        };
     }
 
     #[test]
     fn test_stop_all_workers() {
         let (tx, _) = channel();
-        let mut handler = WorkHandler::new(tx.clone());
+        let handler = WorkHandler::new(tx.clone());
 
-        let range = 10;
-        for _ in 0..range {
-            let _ = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
-                "echo".to_string(),
-                "null".into(),
-            )));
-        }
-        assert_eq!(handler.workers.len(), range);
-        //Can't actually check this calls worker.stop() unless worker becomes a trait
-        handler.stop_all_workers();
-        assert_eq!(handler.workers.len(), 0);
+        if let Ok(mut handler) = handler.lock() {
+            let range = 10;
+            for _ in 0..range {
+                let _ = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
+                    "echo".to_string(),
+                    "null".into(),
+                )));
+            }
+            let stop_flags: Vec<Arc<AtomicBool>> = handler
+                .workers
+                .values()
+                .into_iter()
+                .map(|work_info| work_info.should_stop.clone())
+                .collect();
+            assert_eq!(handler.workers.len(), range);
+            handler.stop_all_workers();
+            for flag in stop_flags {
+                assert!(flag.load(Ordering::Relaxed));
+            }
+            assert_eq!(handler.workers.len(), 0);
+        };
     }
 }

--- a/src/core/work/work_handler.rs
+++ b/src/core/work/work_handler.rs
@@ -1,0 +1,123 @@
+use std::{collections::HashMap, sync::mpsc::Sender};
+
+use crate::models::event::Event;
+
+use super::{work::Work, worker::Worker};
+
+pub struct WorkHandler {
+    workers: HashMap<usize, Worker>,
+    tx: Sender<Event>,
+}
+impl WorkHandler {
+    pub fn new(tx: Sender<Event>) -> Self {
+        WorkHandler {
+            workers: HashMap::new(),
+            tx,
+        }
+    }
+    fn spawn_id(&self) -> usize {
+        loop {
+            let id = rand::random::<usize>();
+            if !self.workers.contains_key(&id) {
+                return id;
+            }
+        }
+    }
+    pub fn spawn_worker(&mut self, work_type: Work) -> usize {
+        let id = self.spawn_id();
+        let mut worker = Worker::new(self.tx.clone(), work_type);
+        worker.run();
+        self.workers.insert(id, worker);
+        id
+    }
+    pub fn stop_worker(&mut self, id: usize) {
+        match self.workers.remove(&id) {
+            Some(mut worker) => worker.stop(),
+            None => (),
+        }
+    }
+    pub fn stop_workers(&mut self, work_type: Work) {
+        self.workers
+            .iter_mut()
+            .filter(|(_, worker)| worker.work_type == work_type)
+            .for_each(|(_, worker)| worker.stop());
+        self.workers
+            .retain(|_, worker| worker.work_type != work_type);
+    }
+    pub fn stop_all_workers(&mut self) {
+        self.workers
+            .iter_mut()
+            .for_each(|(_, worker)| worker.stop());
+        self.workers.clear();
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::channel;
+
+    use super::*;
+    use crate::core::editor::opener::EditorOpener;
+    #[test]
+    fn test_different_ids() {
+        let (tx, _) = channel();
+        let mut handler = WorkHandler::new(tx.clone());
+        let mut last_id: Option<usize> = None;
+        for _ in 0..10 {
+            let id = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
+                "echo".to_string(),
+                "null".into(),
+            )));
+            if last_id.is_none() {
+                last_id = Some(id);
+            } else {
+                assert_ne!(last_id.unwrap(), id);
+            }
+        }
+    }
+    #[test]
+    fn test_spawn_worker() {
+        let (tx, _) = channel();
+        let mut handler = WorkHandler::new(tx.clone());
+
+        let id = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
+            "echo".to_string(),
+            "null".into(),
+        )));
+        assert!(handler.workers.contains_key(&id));
+        matches!(
+            handler.workers.get(&id).unwrap().work_type,
+            Work::EditorOpen(_)
+        );
+    }
+    #[test]
+    fn test_stop_worker() {
+        let (tx, _) = channel();
+        let mut handler = WorkHandler::new(tx.clone());
+
+        let id = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
+            "echo".to_string(),
+            "null".into(),
+        )));
+        //Can't actually check this calls worker.stop() unless worker becomes a trait
+        handler.stop_worker(id);
+        assert!(!handler.workers.contains_key(&id));
+    }
+
+    #[test]
+    fn test_stop_all_workers() {
+        let (tx, _) = channel();
+        let mut handler = WorkHandler::new(tx.clone());
+
+        let range = 10;
+        for _ in 0..range {
+            let _ = handler.spawn_worker(Work::EditorOpen(EditorOpener::new(
+                "echo".to_string(),
+                "null".into(),
+            )));
+        }
+        assert_eq!(handler.workers.len(), range);
+        //Can't actually check this calls worker.stop() unless worker becomes a trait
+        handler.stop_all_workers();
+        assert_eq!(handler.workers.len(), 0);
+    }
+}

--- a/src/core/work/worker.rs
+++ b/src/core/work/worker.rs
@@ -1,80 +1,42 @@
 use crate::models::event::Event;
 
-use super::work::Work;
+use super::{work::Work, work_handler::WorkEvent};
 use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        mpsc::Sender,
-        Arc,
-    },
+    sync::{atomic::AtomicBool, mpsc::Sender, Arc},
     thread::{self, JoinHandle},
 };
 pub struct Worker {
+    id: usize,
+    work_tx: Sender<WorkEvent>,
     pub work_type: Work,
     pub tx: Sender<Event>,
     should_stop: Arc<AtomicBool>,
-    handle: Option<JoinHandle<()>>,
 }
 
 impl Worker {
-    pub fn new(tx: Sender<Event>, work_type: Work) -> Worker {
+    pub fn new(
+        id: usize,
+        work_tx: Sender<WorkEvent>,
+        tx: Sender<Event>,
+        should_stop: Arc<AtomicBool>,
+        work_type: Work,
+    ) -> Worker {
         Worker {
+            id,
+            work_tx,
             tx,
             work_type,
-            should_stop: Arc::new(AtomicBool::new(false)),
-            handle: None,
+            should_stop,
         }
     }
-    pub fn run(&mut self) {
-        match &self.work_type {
+    pub fn run(self) -> JoinHandle<()> {
+        match self.work_type {
             Work::EditorOpen(opener) => {
-                let opener = opener.clone();
-                let tx = self.tx.clone();
-                let should_stop = self.should_stop.clone();
-                self.handle = Some(thread::spawn(move || opener.run(tx, should_stop)));
+                return thread::spawn(move || {
+                    opener.run(self.tx, self.should_stop);
+                    self.work_tx.send(WorkEvent::Done(self.id));
+                });
             }
         }
-    }
-    pub fn stop(&mut self) {
-        self.should_stop.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
-    }
-    pub fn is_stop(&self) -> bool {
-        self.should_stop.load(Ordering::Relaxed)
-    }
-}
-#[cfg(test)]
-mod tests {
-    use std::sync::mpsc::channel;
-
-    use crate::core::editor::opener::EditorOpener;
-
-    use super::*;
-
-    #[test]
-    fn test_stop() {
-        let (tx, _) = channel();
-        let mut worker = Worker::new(
-            tx,
-            Work::EditorOpen(EditorOpener::new("echo".into(), "hello".into())),
-        );
-        assert_eq!(worker.should_stop.load(Ordering::Relaxed), false);
-        worker.stop();
-        assert_eq!(worker.should_stop.load(Ordering::Relaxed), true);
-    }
-    #[test]
-    fn test_handler() {
-        let (tx, _) = channel();
-        let mut worker = Worker::new(
-            tx,
-            Work::EditorOpen(EditorOpener::new("echo".into(), "hello".into())),
-        );
-        assert!(worker.handle.is_none());
-        worker.run();
-        assert!(worker.handle.is_some());
-        worker.stop();
-        assert!(worker.handle.is_none());
     }
 }

--- a/src/core/work/worker.rs
+++ b/src/core/work/worker.rs
@@ -1,0 +1,80 @@
+use crate::models::event::Event;
+
+use super::work::Work;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::Sender,
+        Arc,
+    },
+    thread::{self, JoinHandle},
+};
+pub struct Worker {
+    pub work_type: Work,
+    pub tx: Sender<Event>,
+    should_stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Worker {
+    pub fn new(tx: Sender<Event>, work_type: Work) -> Worker {
+        Worker {
+            tx,
+            work_type,
+            should_stop: Arc::new(AtomicBool::new(false)),
+            handle: None,
+        }
+    }
+    pub fn run(&mut self) {
+        match &self.work_type {
+            Work::EditorOpen(opener) => {
+                let opener = opener.clone();
+                let tx = self.tx.clone();
+                let should_stop = self.should_stop.clone();
+                self.handle = Some(thread::spawn(move || opener.run(tx, should_stop)));
+            }
+        }
+    }
+    pub fn stop(&mut self) {
+        self.should_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+    pub fn is_stop(&self) -> bool {
+        self.should_stop.load(Ordering::Relaxed)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::channel;
+
+    use crate::core::editor::opener::EditorOpener;
+
+    use super::*;
+
+    #[test]
+    fn test_stop() {
+        let (tx, _) = channel();
+        let mut worker = Worker::new(
+            tx,
+            Work::EditorOpen(EditorOpener::new("echo".into(), "hello".into())),
+        );
+        assert_eq!(worker.should_stop.load(Ordering::Relaxed), false);
+        worker.stop();
+        assert_eq!(worker.should_stop.load(Ordering::Relaxed), true);
+    }
+    #[test]
+    fn test_handler() {
+        let (tx, _) = channel();
+        let mut worker = Worker::new(
+            tx,
+            Work::EditorOpen(EditorOpener::new("echo".into(), "hello".into())),
+        );
+        assert!(worker.handle.is_none());
+        worker.run();
+        assert!(worker.handle.is_some());
+        worker.stop();
+        assert!(worker.handle.is_none());
+    }
+}

--- a/src/models/exo.rs
+++ b/src/models/exo.rs
@@ -9,3 +9,16 @@ pub struct Exo {
     checks: Vec<Check>,
     favorite: bool,
 }
+impl Exo {
+    pub fn get_main_file(&self) -> Option<&std::path::PathBuf> {
+        match self.files.iter().find(|file| {
+            if let Some(file_name) = file.file_stem() {
+                return file_name == "main";
+            }
+            return false;
+        }) {
+            Some(file) => Some(file),
+            None => self.files.first(),
+        }
+    }
+}


### PR DESCRIPTION
As mentioned in #43:
> Since the architecture is based on workers, we should be able to manage workers easily

So here's a proposal.

A generic WorkHandler that can spawn workers and stop them when requested.
For now the only Work type we have is EditorOpen but this can be easily extensible to other works with different arguments

This PR also showcases usage of this feature in `core.rs`