### PR TITLE
Feat runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +48,22 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "indexmap"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -57,10 +79,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "ntest"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb183f0a1da7a937f672e5ee7b7edb727bf52b8a52d531374ba8ebb9345c0330"
+dependencies = [
+ "ntest_test_cases",
+ "ntest_timeout",
+]
+
+[[package]]
+name = "ntest_test_cases"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d0d3f2a488592e5368ebbe996e7f1d44aa13156efad201f5b4d84e150eaa93"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ntest_timeout"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc7c92f190c97f79b4a332f5e81dcf68c8420af2045c936c9be0bc9de6f63b5"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "plx"
 version = "0.1.2"
 dependencies = [
  "console",
+ "ntest",
  "rand",
  "similar",
 ]
@@ -72,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -130,6 +201,17 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
@@ -137,6 +219,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -231,6 +330,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,5 +356,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.76",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ exclude = ["*.md"]
 console = "0.15.8"
 rand = "0.8.5"
 similar = { version = "2.6.0", features = ["inline"] }
+
+[dev-dependencies]
+ntest = "0.9.3"

--- a/examples/basics/c/infinite_loop.c
+++ b/examples/basics/c/infinite_loop.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#ifdef _WINDOWS
+#include <windows.h>
+#else
+#include <unistd.h>
+#define Sleep(x) usleep((x)*1000)
+#endif
+
+int main(void)
+{
+	int i = 0;
+	while (1) {
+		++i;
+		printf("Hello %d\n", i);
+		//Make sure we sleep so we don't spam too much
+		Sleep(1000);
+	}
+}

--- a/examples/basics/c/infinite_loop.c
+++ b/examples/basics/c/infinite_loop.c
@@ -12,6 +12,7 @@ int main(void)
 	while (1) {
 		++i;
 		printf("Hello %d\n", i);
+		fflush(stdout);
 		//Make sure we sleep so we don't spam too much
 		Sleep(1000);
 	}

--- a/examples/basics/c/infinite_loop_map_signals.c
+++ b/examples/basics/c/infinite_loop_map_signals.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <signal.h>
+#include <unistd.h>
+
+void handle_signal(int signal)
+{
+	if (signal == SIGTERM) {
+		printf("Received SIGTERM, but ignoring it.\n");
+	} else if (signal == SIGINT) {
+		printf("Received SIGINT, but ignoring it.\n");
+	}
+}
+
+int main()
+{
+	signal(SIGTERM, handle_signal);
+	signal(SIGINT, handle_signal);
+	while (1) {
+		sleep(1);
+	}
+}

--- a/examples/basics/c/wait_stdin.c
+++ b/examples/basics/c/wait_stdin.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <unistd.h>
+
+int main(void)
+{
+	char line[50];
+	while (read(STDIN_FILENO, &line, sizeof(line) - 1) > 0) {
+		line[49] = 0;
+		printf("%s\n", line);
+	}
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -3,4 +3,5 @@ pub mod diff;
 pub mod editor;
 pub mod file_utils;
 pub mod process;
+pub mod runner;
 pub mod work;

--- a/src/core/process/process_handler.rs
+++ b/src/core/process/process_handler.rs
@@ -42,12 +42,16 @@ pub fn get_process_status(child: &mut Child) -> Result<ProcessStatus, ProcessErr
         Err(_) => return Err(ProcessError::WaitChildFail),
     }
 }
+pub fn stop_child(child: &mut Child) -> Result<(), io::Error> {
+    child.kill()
+}
 pub fn wait_child(
     child: &mut Child,
     should_stop: Arc<AtomicBool>,
 ) -> Result<ExitStatus, ProcessError> {
     loop {
         if should_stop.load(Ordering::Relaxed) {
+            let _ = stop_child(child);
             return Err(ProcessError::Quit);
         }
         match get_process_status(child) {

--- a/src/core/process/process_handler.rs
+++ b/src/core/process/process_handler.rs
@@ -45,6 +45,9 @@ pub fn get_process_status(child: &mut Child) -> Result<ProcessStatus, ProcessErr
 pub fn stop_child(child: &mut Child) -> Result<(), io::Error> {
     child.kill()
 }
+pub fn capture_exit_status(child: &mut Child) -> Result<ExitStatus, io::Error> {
+    child.wait()
+}
 pub fn wait_child(
     child: &mut Child,
     should_stop: Arc<AtomicBool>,

--- a/src/core/process/process_handler.rs
+++ b/src/core/process/process_handler.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+#[derive(Debug)]
 pub enum ProcessError {
     WaitChildFail,
     SpawnProcessFail(io::Error),

--- a/src/core/process/process_handler.rs
+++ b/src/core/process/process_handler.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::OsStr,
     io,
-    process::{Child, Command, ExitStatus, Output, Stdio},
+    process::{Child, Command, ExitStatus, Stdio},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,

--- a/src/core/process/process_handler.rs
+++ b/src/core/process/process_handler.rs
@@ -15,13 +15,29 @@ pub enum ProcessError {
     SpawnProcessFail(io::Error),
     Quit,
 }
-pub fn spawn_process(cmd: &String, args: Vec<String>) -> Result<Child, ProcessError> {
+pub enum ProcessStatus {
+    Done(ExitStatus),
+    Running,
+}
+pub fn spawn_process(cmd: &str, args: Vec<String>) -> Result<Child, ProcessError> {
     let child = Command::new(OsStr::new(&cmd))
         .args(args)
         .spawn()
         .map_err(|err| ProcessError::SpawnProcessFail(err))?;
 
     Ok(child)
+}
+pub fn get_process_status(child: &mut Child) -> Result<ProcessStatus, ProcessError> {
+    match child.try_wait() {
+        Ok(status) => match status {
+            Some(exit_status) => Ok(ProcessStatus::Done(exit_status)),
+            None => {
+                sleep(Duration::from_millis(10));
+                Ok(ProcessStatus::Running)
+            }
+        },
+        Err(_) => return Err(ProcessError::WaitChildFail),
+    }
 }
 pub fn wait_child(
     child: &mut Child,
@@ -31,12 +47,16 @@ pub fn wait_child(
         if should_stop.load(Ordering::Relaxed) {
             return Err(ProcessError::Quit);
         }
-        match child.try_wait() {
+        match get_process_status(child) {
             Ok(status) => match status {
-                Some(exit_status) => return Ok(exit_status),
-                None => sleep(Duration::from_millis(10)), //wait till its over,
+                ProcessStatus::Done(exit_status) => return Ok(exit_status),
+                ProcessStatus::Running => {
+                    sleep(Duration::from_millis(10));
+                }
             },
-            Err(_) => return Err(ProcessError::WaitChildFail),
-        };
+            Err(_) => {
+                return Err(ProcessError::WaitChildFail);
+            }
+        }
     }
 }

--- a/src/core/process/process_handler.rs
+++ b/src/core/process/process_handler.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::OsStr,
     io,
-    process::{Child, Command, ExitStatus},
+    process::{Child, Command, ExitStatus, Output, Stdio},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -22,6 +22,8 @@ pub enum ProcessStatus {
 pub fn spawn_process(cmd: &str, args: Vec<String>) -> Result<Child, ProcessError> {
     let child = Command::new(OsStr::new(&cmd))
         .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|err| ProcessError::SpawnProcessFail(err))?;
 

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -1,0 +1,1 @@
+pub mod runner;

--- a/src/core/runner/runner.rs
+++ b/src/core/runner/runner.rs
@@ -152,7 +152,7 @@ mod test {
         };
         // This code blocks reading stdin forever
         let c_file = "./examples/basics/c/wait_stdin.c";
-        let target = "./wait_stdin";
+        let target = "./target/wait_stdin";
         compile_and_run_blocking_program(c_file, target);
     }
 
@@ -164,7 +164,7 @@ mod test {
         };
         // This code does while(1)
         let c_file = "./examples/basics/c/infinite_loop.c";
-        let target = "./infinite_loop";
+        let target = "./target/infinite_loop";
         compile_and_run_blocking_program(c_file, target);
     }
 
@@ -176,7 +176,7 @@ mod test {
         };
         // This code does while(1) and ignores sigterm and sigint
         let c_file = "./examples/basics/c/infinite_loop_map_signals.c";
-        let target = "./infinit_loop_map_signals";
+        let target = "./target/infinit_loop_map_signals";
         compile_and_run_blocking_program(c_file, target);
     }
 
@@ -188,7 +188,7 @@ mod test {
         };
         //This code loops forever and prints Hello <i> every second
         let c_file = "./examples/basics/c/infinite_loop.c";
-        let target = "./infinite_loop_stdout";
+        let target = "./target/infinite_loop_stdout";
         compile_program(c_file, target);
 
         let stop = Arc::new(AtomicBool::new(false));

--- a/src/core/runner/runner.rs
+++ b/src/core/runner/runner.rs
@@ -145,9 +145,11 @@ mod test {
         let _ = std::fs::remove_file(target);
     }
     #[test]
-    #[ignore = "Ignore for now"]
     #[timeout(5000)]
     fn test_stuck_stdin() {
+        if cfg!(windows) {
+            return;
+        };
         // This code blocks reading stdin forever
         let c_file = "./examples/basics/c/wait_stdin.c";
         let target = "./wait_stdin";
@@ -155,9 +157,11 @@ mod test {
     }
 
     #[test]
-    #[ignore = "Ignore for now"]
     #[timeout(5000)]
     fn test_infinite_loop() {
+        if cfg!(windows) {
+            return;
+        };
         // This code does while(1)
         let c_file = "./examples/basics/c/infinite_loop.c";
         let target = "./infinite_loop";
@@ -165,9 +169,11 @@ mod test {
     }
 
     #[test]
-    #[ignore = "Ignore for now"]
     #[timeout(5000)]
     fn test_infinite_loop_with_sig_mapped() {
+        if cfg!(windows) {
+            return;
+        };
         // This code does while(1) and ignores sigterm and sigint
         let c_file = "./examples/basics/c/infinite_loop_map_signals.c";
         let target = "./infinit_loop_map_signals";
@@ -175,9 +181,11 @@ mod test {
     }
 
     #[test]
-    #[ignore = "Ignore for now"]
     #[timeout(10000)]
     fn test_stdout_during_run() {
+        if cfg!(windows) {
+            return;
+        };
         //This code loops forever and prints Hello <i> every second
         let c_file = "./examples/basics/c/infinite_loop.c";
         let target = "./infinite_loop_stdout";

--- a/src/core/runner/runner.rs
+++ b/src/core/runner/runner.rs
@@ -1,0 +1,159 @@
+use std::{
+    io::{BufRead, BufReader, Read},
+    process::ExitStatus,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::Sender,
+        Arc,
+    },
+    thread::{self, sleep, JoinHandle},
+    time::Duration,
+};
+
+use crate::{
+    core::process::process_handler::{self, ProcessStatus},
+    models::event::Event,
+};
+
+pub struct Runner {
+    command: String,
+    args: Vec<String>,
+}
+
+impl Runner {
+    pub fn new(command: String, args: Vec<String>) -> Self {
+        Self { command, args }
+    }
+
+    fn read_stream<T: Read>(tx: Sender<Event>, stdout: T) {
+        let reader = BufReader::new(stdout);
+        reader.lines().for_each(|line| match line {
+            Ok(line) => {
+                let _ = tx.send(Event::ProcessOutputLine(line));
+            }
+            Err(_) => return,
+        });
+    }
+    fn launch_stream_reader<T>(tx: Sender<Event>, stream: T) -> JoinHandle<()>
+    where
+        T: Read + Send + 'static,
+    {
+        thread::spawn(move || Runner::read_stream(tx, stream))
+    }
+
+    pub fn run(self, tx: Sender<Event>, should_stop: Arc<AtomicBool>) -> Result<ExitStatus, ()> {
+        let mut process =
+            process_handler::spawn_process(&self.command, self.args).map_err(|_err| {
+                let _ = tx.send(Event::ProcessCreationFailed);
+            })?;
+
+        let mut stdout_thread = {
+            if let Some(stdout) = process.stdout.take() {
+                Some(Runner::launch_stream_reader(tx.clone(), stdout))
+            } else {
+                None
+            }
+        };
+        let mut stderr_thread = {
+            if let Some(stderr) = process.stderr.take() {
+                Some(Runner::launch_stream_reader(tx.clone(), stderr))
+            } else {
+                None
+            }
+        };
+
+        let exit_status = loop {
+            if should_stop.load(Ordering::Relaxed) {
+                if process_handler::stop_child(&mut process).is_err() {
+                    //Couldn't kill child process
+                    eprintln!("Couldn't kill child process");
+                    break None;
+                }
+                break process_handler::capture_exit_status(&mut process).ok();
+            }
+            match process_handler::get_process_status(&mut process) {
+                Err(_) => break None,
+                Ok(ProcessStatus::Done(status)) => break Some(status),
+                Ok(ProcessStatus::Running) => {
+                    sleep(Duration::from_millis(100));
+                }
+            };
+        };
+
+        if let Some(t) = stdout_thread.take() {
+            let _ = t.join();
+        }
+
+        if let Some(t) = stderr_thread.take() {
+            let _ = t.join();
+        }
+        exit_status.ok_or(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{process::Command, sync::mpsc::channel};
+
+    use ntest::timeout;
+
+    use super::*;
+
+    fn compile_program(c_file: &str, file_name: &str) {
+        Command::new("gcc")
+            .arg(c_file)
+            .arg("-o")
+            .arg(file_name)
+            .output()
+            .expect("Couldn't compile program");
+    }
+    fn run_blocking_program(file_name: &str) {
+        let runner = Runner::new(file_name.to_string(), vec![]);
+
+        let (tx, _) = channel();
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = stop.clone();
+
+        let handler = thread::spawn(move || runner.run(tx, thread_stop));
+        sleep(Duration::from_secs(1));
+
+        // Stop should kill the process no matter the condition it is in
+        stop.store(true, Ordering::Relaxed);
+
+        handler
+            .join()
+            .expect("Couldn't join thread")
+            .expect("Couldn't get child exit status");
+    }
+    fn compile_and_run_blocking_program(c_file: &str, file_name: &str) {
+        compile_program(c_file, file_name);
+        run_blocking_program(file_name);
+        let _ = std::fs::remove_file(file_name);
+    }
+    #[test]
+    #[timeout(2000)]
+    fn test_stuck_stdin() {
+        // This code blocks reading stdin forever
+        let c_file = "./examples/basics/c/wait_stdin.c";
+        let file_name = "./wait_stdin";
+        compile_and_run_blocking_program(c_file, file_name);
+    }
+
+    #[test]
+    #[timeout(2000)]
+    fn test_infinite_loop() {
+        // This code does while(1)
+        let c_file = "./examples/basics/c/infinite_loop.c";
+        let file_name = "./infinit_loop";
+        compile_and_run_blocking_program(c_file, file_name);
+    }
+
+    #[test]
+    #[timeout(2000)]
+    fn test_infinite_loop_with_sig_mapped() {
+        // This code does while(1)
+        let c_file = "./examples/basics/c/infinite_loop_map_signals.c";
+        let file_name = "./infinit_loop_map_signals";
+        compile_and_run_blocking_program(c_file, file_name);
+    }
+}

--- a/src/core/runner/runner.rs
+++ b/src/core/runner/runner.rs
@@ -145,7 +145,7 @@ mod test {
         let _ = std::fs::remove_file(file_name);
     }
     #[test]
-    #[timeout(2000)]
+    #[timeout(5000)]
     fn test_stuck_stdin() {
         // This code blocks reading stdin forever
         let c_file = "./examples/basics/c/wait_stdin.c";
@@ -154,7 +154,7 @@ mod test {
     }
 
     #[test]
-    #[timeout(2000)]
+    #[timeout(5000)]
     fn test_infinite_loop() {
         // This code does while(1)
         let c_file = "./examples/basics/c/infinite_loop.c";
@@ -163,7 +163,7 @@ mod test {
     }
 
     #[test]
-    #[timeout(2000)]
+    #[timeout(5000)]
     fn test_infinite_loop_with_sig_mapped() {
         // This code does while(1) and ignores sigterm and sigint
         let c_file = "./examples/basics/c/infinite_loop_map_signals.c";

--- a/src/core/runner/runner.rs
+++ b/src/core/runner/runner.rs
@@ -195,5 +195,6 @@ mod test {
             .join()
             .expect("Couldn't join thread")
             .expect("Couldn't get child exit status");
+        let _ = std::fs::remove_file(file_name);
     }
 }

--- a/src/core/runner/runner.rs
+++ b/src/core/runner/runner.rs
@@ -145,6 +145,7 @@ mod test {
         let _ = std::fs::remove_file(file_name);
     }
     #[test]
+    #[ignore = "Ignore for now"]
     #[timeout(5000)]
     fn test_stuck_stdin() {
         // This code blocks reading stdin forever
@@ -154,6 +155,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "Ignore for now"]
     #[timeout(5000)]
     fn test_infinite_loop() {
         // This code does while(1)
@@ -163,6 +165,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "Ignore for now"]
     #[timeout(5000)]
     fn test_infinite_loop_with_sig_mapped() {
         // This code does while(1) and ignores sigterm and sigint
@@ -172,6 +175,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "Ignore for now"]
     #[timeout(10000)]
     fn test_stdout_during_run() {
         //This code loops forever and prints Hello <i> every second

--- a/src/core/runner/runner.rs
+++ b/src/core/runner/runner.rs
@@ -144,7 +144,7 @@ mod test {
     fn test_infinite_loop() {
         // This code does while(1)
         let c_file = "./examples/basics/c/infinite_loop.c";
-        let file_name = "./infinit_loop";
+        let file_name = "./infinite_loop";
         compile_and_run_blocking_program(c_file, file_name);
     }
 

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -5,4 +5,6 @@ pub enum Event {
     KeyPressed(Key),
     EditorOpened,
     CouldNotOpenEditor,
+    ProcessCreationFailed,
+    ProcessOutputLine(String),
 }


### PR DESCRIPTION
Features:

- Added [ntest](https://docs.rs/ntest/latest/ntest/) as a dev-dependency that it can be used to set a test timeout
- Added some more C code examples of blocking programs, either by reading from stdin or by simply creating an infinite loop
- Changes to the way we create processes so we can pipe stdout and stderr and treat them as we wish
- A Runner implementation that can be started with a program and some args and it will correctly feed stdout and stderr to the rest of the app using the event system
- Tests were made to make sure the runner can be stopped whenever we wish, even if the child process is in an infinite loop

This can be easily used to run any process we wish, including compiling or opening an editor for instance

I suppose once we start putting everything together there will be some refactoring to do 