### PR TITLE
Feat: Help page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "rand",
  "ratatui",
  "similar",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ rand = "0.8.5"
 ratatui = "0.28.1"
 crossterm = "0.28.1"
 similar = { version = "2.6.0", features = ["inline"] }
+strum = "0.26.3"

--- a/src/core/app/event_handler.rs
+++ b/src/core/app/event_handler.rs
@@ -24,8 +24,7 @@ impl App {
 
     // Function to check if we're not already on the help page else we won't be able to exit.
     pub(super) fn on_interrogation(&mut self, last_state: Box<UiState>, scroll_offset: usize) {
-        // assert!(matches!(&self.ui_state, UiState::Help { last_state, scroll_offset}));
-        if matches!(&self.ui_state, UiState::Help { .. }) {
+        if !matches!(&self.ui_state, UiState::Help { .. }) {
             self.go_to_help(last_state, scroll_offset);
         }
     }

--- a/src/core/app/event_handler.rs
+++ b/src/core/app/event_handler.rs
@@ -18,19 +18,15 @@ impl App {
             Key::P => todo!(),
             Key::E => todo!(),
             Key::Esc => self.on_esc(),
-            Key::Interrogation => self.is_on_help(Box::new(self.ui_state.clone()), 0),
+            Key::Interrogation => self.on_interrogation(Box::new(self.ui_state.clone()), 0),
         }
     }
 
     // Function to check if we're not already on the help page else we won't be able to exit.
-    pub(super) fn is_on_help(&mut self, last_state: Box<UiState>, scroll_offset: usize) {
-        if self.ui_state
-            != (UiState::Help {
-                last_state,
-                scroll_offset,
-            })
-        {
-            self.go_to_help(Box::new(self.ui_state.clone()), 0);
+    pub(super) fn on_interrogation(&mut self, last_state: Box<UiState>, scroll_offset: usize) {
+        // assert!(matches!(&self.ui_state, UiState::Help { last_state, scroll_offset}));
+        if matches!(&self.ui_state, UiState::Help { .. }) {
+            self.go_to_help(last_state, scroll_offset);
         }
     }
 

--- a/src/core/app/event_handler.rs
+++ b/src/core/app/event_handler.rs
@@ -18,9 +18,22 @@ impl App {
             Key::P => todo!(),
             Key::E => todo!(),
             Key::Esc => self.on_esc(),
-            Key::Interrogation => self.go_to_help(Box::new(self.ui_state.clone()), 0),
+            Key::Interrogation => self.is_on_help(Box::new(self.ui_state.clone()), 0),
         }
     }
+
+    // Function to check if we're not already on the help page else we won't be able to exit.
+    pub(super) fn is_on_help(&mut self, last_state: Box<UiState>, scroll_offset: usize) {
+        if self.ui_state
+            != (UiState::Help {
+                last_state,
+                scroll_offset,
+            })
+        {
+            self.go_to_help(Box::new(self.ui_state.clone()), 0);
+        }
+    }
+
     pub(super) fn on_process_creation_fail(&mut self, run_id: usize, err: String) {
         if let Some(ref mut cr) = self.current_run {
             if run_id < cr.check_results.len() {

--- a/src/models/check_state.rs
+++ b/src/models/check_state.rs
@@ -13,7 +13,7 @@ pub enum CheckStatus {
     RunFail(String),
     Pending,
 }
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CheckState {
     pub(crate) check: Arc<Check>,
     pub(crate) status: CheckStatus,

--- a/src/models/key.rs
+++ b/src/models/key.rs
@@ -47,7 +47,7 @@ impl Key {
     /// An alternative key, can be empty
     pub fn alt(&self) -> &str {
         match self {
-            Key::Q => "ctrl+c",
+            // Key::Q => "ctrl+c", TODO: use sigint / sigterm signals to handle shortcut
             Key::H => "left",
             Key::J => "down",
             Key::K => "up",

--- a/src/models/key.rs
+++ b/src/models/key.rs
@@ -22,7 +22,7 @@ impl Key {
         match self {
             Key::Q => "Quit the TUI",
             Key::R => "Resume progress to latest or next exo",
-            Key::H => "Move left", 
+            Key::H => "Move left",
             Key::J => "Move down",
             Key::K => "Move up",
             Key::L => "Move right",

--- a/src/models/key.rs
+++ b/src/models/key.rs
@@ -21,15 +21,15 @@ impl Key {
         match self {
             Key::Q => "Quit the TUI",
             Key::R => "Resume progress to latest or next exo",
-            Key::H => "", //TODO: fill those
-            Key::J => "",
-            Key::K => "",
-            Key::L => "",
-            Key::N => "",
-            Key::P => "",
-            Key::E => "",
-            Key::Enter => "",
-            Key::Esc => "",
+            Key::H => "Move left", 
+            Key::J => "Move down",
+            Key::K => "Move up",
+            Key::L => "Move right",
+            Key::N => "Next test",
+            Key::P => "Previous test",
+            Key::E => "Edit exercise",
+            Key::Enter => "Enter to continue",
+            Key::Esc => "Go back",
         }
     }
     /// An alternative key, can be empty

--- a/src/models/key.rs
+++ b/src/models/key.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, PartialEq, Eq)]
+use strum::{EnumIter, IntoStaticStr};
+
+#[derive(Debug, PartialEq, Eq, EnumIter, IntoStaticStr)]
 pub enum Key {
     Q,
     R,
@@ -11,4 +13,34 @@ pub enum Key {
     E,
     Enter,
     Esc,
+}
+
+impl Key {
+    /// Get the human description of the key
+    pub fn describe(&self) -> &str {
+        match self {
+            Key::Q => "Quit the TUI",
+            Key::R => "Resume progress to latest or next exo",
+            Key::H => "", //TODO: fill those
+            Key::J => "",
+            Key::K => "",
+            Key::L => "",
+            Key::N => "",
+            Key::P => "",
+            Key::E => "",
+            Key::Enter => "",
+            Key::Esc => "",
+        }
+    }
+    /// An alternative key, can be empty
+    pub fn alt(&self) -> &str {
+        match self {
+            Key::Q => "ctrl+c",
+            Key::H => "left",
+            Key::J => "down",
+            Key::K => "up",
+            Key::L => "right",
+            _ => "",
+        }
+    }
 }

--- a/src/models/key.rs
+++ b/src/models/key.rs
@@ -13,6 +13,7 @@ pub enum Key {
     E,
     Enter,
     Esc,
+    Interrogation,
 }
 
 impl Key {
@@ -30,8 +31,19 @@ impl Key {
             Key::E => "Edit exercise",
             Key::Enter => "Enter to continue",
             Key::Esc => "Go back",
+            Key::Interrogation => "View help",
         }
     }
+
+    /// Define a key name, by default the lowercase version of the enum case
+    /// but it can also be used to rename special keys like Interrogation -> ?
+    pub fn name(&self) -> String {
+        match self {
+            Key::Interrogation => "?".to_string(),
+            _ => format!("{:?}", self).to_lowercase(),
+        }
+    }
+
     /// An alternative key, can be empty
     pub fn alt(&self) -> &str {
         match self {

--- a/src/models/ui_state.rs
+++ b/src/models/ui_state.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use super::{check_state::CheckState, exo::Exo, skill::Skill};
 
 // The list of states and associated values for the UI to represent
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum UiState {
     Home, // Home page with ASCII art
     Quit, // Exit in progress

--- a/src/ui/pages.rs
+++ b/src/ui/pages.rs
@@ -1,2 +1,2 @@
-pub mod home;
 pub mod help;
+pub mod home;

--- a/src/ui/pages.rs
+++ b/src/ui/pages.rs
@@ -1,1 +1,2 @@
 pub mod home;
+pub mod help;

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -26,15 +26,15 @@ pub fn render_help(frame: &mut Frame) {
     // USING TABLE
     let mut rows = Vec::new();
     for k in Key::iter() {
-        let key = Text::from(format!("{:#?}", k))
+        let key = Text::from(format!("{:?}", k))
             .style(Style::default().fg(Color::Green))
             .alignment(ratatui::layout::Alignment::Left);
 
-        let description = Text::from(format!("{:?}", k.describe()))
+        let description = Text::from(format!("{}", k.describe()))
             .style(Style::default().fg(Color::White))
             .centered();
 
-        let alt = Text::from(format!("{:?}", k.alt()))
+        let alt = Text::from(format!("{}", k.alt()))
             .style(Style::default().fg(Color::Blue))
             .alignment(ratatui::layout::Alignment::Right);
 

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -9,7 +9,7 @@ use strum::IntoEnumIterator;
 
 use crate::models::key::Key;
 
-pub fn render_help(frame: &mut Frame) {
+pub fn render_help(frame: &mut Frame, _scroll_offset: usize) {
     // USING TABLE
     let mut rows = Vec::new();
     let mut max_shortcut_text_length: u16 = 0;
@@ -19,12 +19,13 @@ pub fn render_help(frame: &mut Frame) {
             .dim();
 
         let mut shortcut_text = Line::default();
-        let shortcut_name = format!("{:?}", k);
-        shortcut_text.push_span(Span::from(shortcut_name.to_lowercase()).green());
+        let shortcut_name = &k.name();
+        shortcut_text.push_span(Span::from(shortcut_name.clone()).green());
         let mut length_count: u16 = shortcut_name.len() as u16;
-        if !k.alt().is_empty() {
+        let alt = k.alt().to_string();
+        if !alt.is_empty() {
             shortcut_text.push_span(Span::from(", ").dim());
-            shortcut_text.push_span(Span::from(k.alt().to_lowercase()).green());
+            shortcut_text.push_span(Span::from(alt).green());
             length_count += k.alt().len() as u16 + 2;
         }
 

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -10,10 +10,48 @@ use strum::IntoEnumIterator;
 use crate::models::key::Key;
 
 pub fn render_help(frame: &mut Frame) {
+    // Create a layout with a full screen display
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([Constraint::Percentage(100)].as_ref())
+        .split(frame.area());
+
+    // Create a block with borders
+    let block = Block::default().borders(Borders::NONE).title("Help");
+
+    // Render the block with borders
+    frame.render_widget(block, layout[0]);
+
+    // Collect all items into a single list
+    let mut items = Vec::new();
     for k in Key::iter() {
-        println!("{}", format!("{:?} {} {}", k, k.describe(), k.alt()));
+        let key = Text::from(format!("{:?}", k)).style(Style::default().fg(Color::Green));
+
+        let description =
+            Text::from(format!("{:?}", k.describe())).style(Style::default().fg(Color::Blue));
+
+        let alt = Text::from(format!("{:?}", k.alt()));
+
+        // Combine all 3 items into a single line
+        // if alt is different from empty string then add it to the line
+
+        if alt != Text::from("") {
+            let combined_text = format!("{} {} (alt: {})", key, description, alt);
+            items.push(combined_text);
+        } else {
+            let combined_text = format!("{} {}", key, description);
+            items.push(combined_text);
+        }
     }
 
-    // Render the help paragraph in the first chunk
-    // frame.render_widget(help_paragraph, chunks[0]);
+    // Create a single list with all items
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Key Descriptions"),
+    );
+
+    // Render the list inside the inner layout
+    frame.render_widget(list, layout[0]);
 }

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -1,8 +1,8 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
-    style::{Color, Style, Styled, Stylize},
-    text::Text,
-    widgets::{Block, Borders, Row, Table},
+    layout::Constraint,
+    style::{Color, Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Row, Table},
     Frame,
 };
 use strum::IntoEnumIterator;
@@ -10,45 +10,41 @@ use strum::IntoEnumIterator;
 use crate::models::key::Key;
 
 pub fn render_help(frame: &mut Frame) {
-    // Create a layout with a full screen display
-    let layout = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(1)
-        .constraints([Constraint::Percentage(100)].as_ref())
-        .split(frame.area());
-
-    // Create a block with borders
-    let block = Block::default().borders(Borders::NONE).title("Help");
-
-    // Render the block with borders
-    frame.render_widget(block, layout[0]);
-
     // USING TABLE
     let mut rows = Vec::new();
+    let mut max_shortcut_text_length: u16 = 0;
     for k in Key::iter() {
+        let description = Line::from(format!("{}", k.describe()))
+            .style(Style::default().fg(Color::White))
+            .dim();
 
-        let description = Text::from(format!("{}", k.describe()))
-            .style(Style::default().fg(Color::White)).dim();
+        let mut shortcut_text = Line::default();
+        let shortcut_name = format!("{:?}", k);
+        shortcut_text.push_span(Span::from(shortcut_name.to_lowercase()).green());
+        let mut length_count: u16 = shortcut_name.len() as u16;
+        if !k.alt().is_empty() {
+            shortcut_text.push_span(Span::from(", ").dim());
+            shortcut_text.push_span(Span::from(k.alt().to_lowercase()).green());
+            length_count += k.alt().len() as u16 + 2;
+        }
 
-        let key_and_alt = Text::from(format!("{:?}, {}", k, k.alt()).to_lowercase()).style(Style::default().fg(Color::Green));
+        if length_count > max_shortcut_text_length {
+            max_shortcut_text_length = length_count;
+        }
 
-        let row = Row::new(vec![key_and_alt, description]);
+        let row = Row::new(vec![Line::from(shortcut_text), description]);
         rows.push(row);
-
     }
-        
-    // 2 columns table | shortcut, alt | description |
-    // Create a table with 2 columns
+
+    //TODO: skip first rows to respect given offset to be able to scroll down
+
+    // Create a table with 2 columns: | shortcut, alt | description |
     let table = Table::new(rows, vec![Constraint::Percentage(100)])
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title("Key Descriptions"),
-        )
+        .block(Block::default().title("Help of shortcuts"))
         .widths(&[
-            Constraint::Percentage(10),
+            Constraint::Min(max_shortcut_text_length),
             Constraint::Percentage(90),
         ]);
 
-    frame.render_widget(table, layout[0]);
+    frame.render_widget(table, frame.area());
 }

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -1,9 +1,6 @@
+
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
-    style::{Color, Style},
-    text::Text,
-    widgets::{Block, Borders, List, ListState, Table},
-    Frame,
+    layout::{Constraint, Direction, Layout}, style::{Color, Style}, text::Text, widgets::{Block, Borders, Row, Table}, Frame
 };
 use strum::IntoEnumIterator;
 
@@ -23,35 +20,33 @@ pub fn render_help(frame: &mut Frame) {
     // Render the block with borders
     frame.render_widget(block, layout[0]);
 
-    // Collect all items into a single list
-    let mut items = Vec::new();
+    // USING TABLE
+    let mut rows = Vec::new();
     for k in Key::iter() {
         let key = Text::from(format!("{:?}", k)).style(Style::default().fg(Color::Green));
 
         let description =
-            Text::from(format!("{:?}", k.describe())).style(Style::default().fg(Color::Blue));
+            Text::from(format!("{:?}", k.describe())).style(Style::default().fg(Color::White));  
 
-        let alt = Text::from(format!("{:?}", k.alt()));
+        let alt = Text::from(format!("{:?}", k.alt())).style(Style::default().fg(Color::Blue));
 
-        // Combine all 3 items into a single line
-        // if alt is different from empty string then add it to the line
+        let row = Row::new(vec![key, description, alt]);
 
-        if alt != Text::from("") {
-            let combined_text = format!("{} {} (alt: {})", key, description, alt);
-            items.push(combined_text);
-        } else {
-            let combined_text = format!("{} {}", key, description);
-            items.push(combined_text);
-        }
+        rows.push(row);
+
     }
 
-    // Create a single list with all items
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title("Key Descriptions"),
-    );
+    // Create a table with 3 columns
+    let table = Table::new(rows, vec![
+        Constraint::Percentage(33),
+        Constraint::Percentage(34),
+        Constraint::Percentage(33),
+    ])
+    .block(Block::default().borders(Borders::ALL).title("Key Descriptions"))
+    .widths(&[Constraint::Percentage(33), Constraint::Percentage(34), Constraint::Percentage(33)]); 
 
-    // Render the list inside the inner layout
-    frame.render_widget(list, layout[0]);
+
+    frame.render_widget(table, layout[0]);
+
 }
+

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -26,19 +26,13 @@ pub fn render_help(frame: &mut Frame) {
     // USING TABLE
     let mut rows = Vec::new();
     for k in Key::iter() {
-        let key = Text::from(format!("{:?}", k))
-            .style(Style::default().fg(Color::Green))
-            .alignment(ratatui::layout::Alignment::Left);
 
         let description = Text::from(format!("{}", k.describe()))
-            .style(Style::default().fg(Color::White))
-            .centered();
+            .style(Style::default().fg(Color::White)).dim();
 
-        let alt = Text::from(format!("{}", k.alt()))
-            .style(Style::default().fg(Color::Blue))
-            .alignment(ratatui::layout::Alignment::Right);
+        let key_and_alt = Text::from(format!("{:?}, {}", k, k.alt()).to_lowercase()).style(Style::default().fg(Color::Green));
 
-        let row = Row::new(vec![key, description, alt]);
+        let row = Row::new(vec![key_and_alt, description]);
         rows.push(row);
 
     }

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -1,8 +1,8 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Style, Stylize},
-    text::{Line, Span, Text},
-    widgets::{Block, Borders, Paragraph},
+    style::{Color, Style},
+    text::Text,
+    widgets::{Block, Borders, List, ListState, Table},
     Frame,
 };
 use strum::IntoEnumIterator;

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -1,37 +1,19 @@
-use ratatui::{layout::{Constraint, Direction, Layout}, style::{Color, Style, Stylize}, text::{Line, Span, Text}, widgets::{Block, Borders, Paragraph}, Frame};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style, Stylize},
+    text::{Line, Span, Text},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+use strum::IntoEnumIterator;
+
+use crate::models::key::Key;
 
 pub fn render_help(frame: &mut Frame) {
-    //TODO
-
-    let quick_help_lines = vec![    
-        "Type r to resume progress",
-        "Type l to list all exos",
-        "Type ? to display help",
-        "Type q to quit",
-    ];
-
-    let mut lines: Vec<Line> = vec![];
-    lines.push(Line::default()); //margin top
-    lines.push(Line::from("Quick help").bold()); //margin top for quick help
-    for l in quick_help_lines {
-        lines.push(Line::from(l).dim());
+    for k in Key::iter() {
+        println!("{}", format!("{:?} {} {}", k, k.describe(), k.alt()));
     }
 
-    let help_text = quick_help_lines
-        .iter()
-        .map(|&line| Span::from(Span::raw(line)))
-        .collect::<Vec<_>>();
-
-    let help_paragraph = Paragraph::new(Text::from(help_text))
-        .block(Block::default().borders(Borders::ALL).title("Quick Help"))
-        .style(Style::default().fg(Color::White).bg(Color::Black));
-
-    // Set up the layout
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(100)].as_ref())
-        .split(frame.area());
-
     // Render the help paragraph in the first chunk
-    frame.render_widget(help_paragraph, chunks[0]);
+    // frame.render_widget(help_paragraph, chunks[0]);
 }

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -1,0 +1,3 @@
+pub fn render_help() {
+    //TODO
+}

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -1,3 +1,37 @@
-pub fn render_help() {
+use ratatui::{layout::{Constraint, Direction, Layout}, style::{Color, Style, Stylize}, text::{Line, Span, Text}, widgets::{Block, Borders, Paragraph}, Frame};
+
+pub fn render_help(frame: &mut Frame) {
     //TODO
+
+    let quick_help_lines = vec![    
+        "Type r to resume progress",
+        "Type l to list all exos",
+        "Type ? to display help",
+        "Type q to quit",
+    ];
+
+    let mut lines: Vec<Line> = vec![];
+    lines.push(Line::default()); //margin top
+    lines.push(Line::from("Quick help").bold()); //margin top for quick help
+    for l in quick_help_lines {
+        lines.push(Line::from(l).dim());
+    }
+
+    let help_text = quick_help_lines
+        .iter()
+        .map(|&line| Span::from(Span::raw(line)))
+        .collect::<Vec<_>>();
+
+    let help_paragraph = Paragraph::new(Text::from(help_text))
+        .block(Block::default().borders(Borders::ALL).title("Quick Help"))
+        .style(Style::default().fg(Color::White).bg(Color::Black));
+
+    // Set up the layout
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(100)].as_ref())
+        .split(frame.area());
+
+    // Render the help paragraph in the first chunk
+    frame.render_widget(help_paragraph, chunks[0]);
 }

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Style, Stylize},
+    style::{Color, Style, Styled, Stylize},
     text::Text,
     widgets::{Block, Borders, Row, Table},
     Frame,

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -1,6 +1,9 @@
-
 use ratatui::{
-    layout::{Constraint, Direction, Layout}, style::{Color, Style}, text::Text, widgets::{Block, Borders, Row, Table}, Frame
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style, Stylize},
+    text::Text,
+    widgets::{Block, Borders, Row, Table},
+    Frame,
 };
 use strum::IntoEnumIterator;
 
@@ -23,30 +26,35 @@ pub fn render_help(frame: &mut Frame) {
     // USING TABLE
     let mut rows = Vec::new();
     for k in Key::iter() {
-        let key = Text::from(format!("{:?}", k)).style(Style::default().fg(Color::Green));
+        let key = Text::from(format!("{:#?}", k))
+            .style(Style::default().fg(Color::Green))
+            .alignment(ratatui::layout::Alignment::Left);
 
-        let description =
-            Text::from(format!("{:?}", k.describe())).style(Style::default().fg(Color::White));  
+        let description = Text::from(format!("{:?}", k.describe()))
+            .style(Style::default().fg(Color::White))
+            .centered();
 
-        let alt = Text::from(format!("{:?}", k.alt())).style(Style::default().fg(Color::Blue));
+        let alt = Text::from(format!("{:?}", k.alt()))
+            .style(Style::default().fg(Color::Blue))
+            .alignment(ratatui::layout::Alignment::Right);
 
         let row = Row::new(vec![key, description, alt]);
-
         rows.push(row);
 
     }
 
     // Create a table with 3 columns
-    let table = Table::new(rows, vec![
-        Constraint::Percentage(33),
-        Constraint::Percentage(34),
-        Constraint::Percentage(33),
-    ])
-    .block(Block::default().borders(Borders::ALL).title("Key Descriptions"))
-    .widths(&[Constraint::Percentage(33), Constraint::Percentage(34), Constraint::Percentage(33)]); 
-
+    let table = Table::new(rows, vec![Constraint::Percentage(100)])
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Key Descriptions"),
+        )
+        .widths(&[
+            Constraint::Percentage(33),
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+        ]);
 
     frame.render_widget(table, layout[0]);
-
 }
-

--- a/src/ui/pages/help.rs
+++ b/src/ui/pages/help.rs
@@ -42,8 +42,9 @@ pub fn render_help(frame: &mut Frame) {
         rows.push(row);
 
     }
-
-    // Create a table with 3 columns
+        
+    // 2 columns table | shortcut, alt | description |
+    // Create a table with 2 columns
     let table = Table::new(rows, vec![Constraint::Percentage(100)])
         .block(
             Block::default()
@@ -51,9 +52,8 @@ pub fn render_help(frame: &mut Frame) {
                 .title("Key Descriptions"),
         )
         .widths(&[
-            Constraint::Percentage(33),
-            Constraint::Percentage(34),
-            Constraint::Percentage(33),
+            Constraint::Percentage(10),
+            Constraint::Percentage(90),
         ]);
 
     frame.render_widget(table, layout[0]);

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -79,6 +79,7 @@ impl Ui<'_> {
     fn render_frame(&self, frame: &mut Frame, state: &UiState) -> bool {
         match state {
             UiState::Home => home::render_home(frame),
+            UiState::Help => help::render_help(frame),
             UiState::Quit => return false, //TODO: this is the way we try to quit for now
             //TODO all other pages
             _ => {}

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -54,7 +54,7 @@ impl Ui {
     fn render_frame(&self, frame: &mut Frame, state: &UiState) {
         match state {
             UiState::Home => home::render_home(frame),
-            UiState::Help => help::render_help(frame),
+            UiState::Help { scroll_offset, .. } => help::render_help(frame, *scroll_offset),
             UiState::Quit => return,
             //TODO all other pages
             _ => {}

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -39,6 +39,7 @@ pub fn ui_key_to_core_key(key: &KeyCode) -> Option<Key> {
         KeyCode::Char('l') | KeyCode::Right => Some(Key::L),
         KeyCode::Enter => Some(Key::Enter),
         KeyCode::Esc => Some(Key::Esc),
+        KeyCode::Char('?') => Some(Key::Interrogation),
         _ => None,
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c5b2c5af-dc3a-4a05-bb35-e756efb6078b)
This PR adds a nice help page accessible via `?`.

It also adds methods `Key.describe()` to get description, `Key.name()` to get the case name or a hardcoded symbol (Interrogation -> ?), and `Key.alt()` to indicate a possible alternative.

It needs a new crate `strum` to be able to iterate on enum cases and get the enum case name as string.

We couldn't have a completely dynamic system, this structure still need manual maintenance of alternatives as they are only defined in the UI.