### PR TITLE
refactor: move compiler args from runner to compiler

### DIFF
--- a/src/core/compiler/compile_runner.rs
+++ b/src/core/compiler/compile_runner.rs
@@ -25,17 +25,7 @@ impl CompileRunner {
     // added to the output_path before calling this function
     pub fn new(compiler: &Compiler, exo: &Exo, output_path: &std::path::PathBuf) -> Option<Self> {
         let cmd = compiler.cmd();
-        let mut args = compiler.args(&exo.files);
-        match output_path.to_str() {
-            Some(path) => {
-                // TODO this should probably somewhere else like `compiler` because this is
-                // specific to gcc/g++
-                args.push(String::from("-fdiagnostics-color=always"));
-                args.push(String::from("-o"));
-                args.push(String::from(path));
-            }
-            None => return None,
-        }
+        let args = compiler.args(&exo.files, output_path);
         Some(Self {
             runner: Runner::new(String::from(cmd), args),
         })

--- a/src/core/compiler/compiler.rs
+++ b/src/core/compiler/compiler.rs
@@ -16,13 +16,29 @@ impl Compiler {
     }
 
     /// Gets the correct arguments to launch the compiler
-    /// TODO maybe this should also be responsible for adding -o in gcc/g++
-    /// Would make it easier to add new compilers without changing  `compile_runner`
-    pub fn args(&self, files: &Vec<std::path::PathBuf>) -> Vec<String> {
+    pub fn args(
+        &self,
+        files: &Vec<std::path::PathBuf>,
+        output_path: &std::path::PathBuf,
+    ) -> Vec<String> {
         match self {
-            Compiler::Gcc => Compiler::collect_files_with_extension(files, &["c"]),
-            Compiler::Gxx => Compiler::collect_files_with_extension(files, &["c", "cpp", "cc"]),
+            Compiler::Gcc => Compiler::gxx_args(files, output_path, &["c"]),
+            Compiler::Gxx => Compiler::gxx_args(files, output_path, &["c", "cpp", "cc"]),
         }
+    }
+    fn gxx_args(
+        files: &Vec<std::path::PathBuf>,
+        output_path: &std::path::PathBuf,
+        extensions: &[&str],
+    ) -> Vec<String> {
+        let path = output_path.to_str().unwrap_or("");
+        let mut args = Compiler::collect_files_with_extension(files, extensions);
+        args.extend([
+            String::from("-fdiagnostics-color=always"),
+            String::from("-o"),
+            String::from(path),
+        ]);
+        return args;
     }
 
     /// Collects the files in `files` that have an extension found in `allowed_extensions`

--- a/src/core/file_utils/file_utils.rs
+++ b/src/core/file_utils/file_utils.rs
@@ -35,6 +35,10 @@ pub fn list_dir_files(dir: &std::path::PathBuf) -> Result<Vec<std::path::PathBuf
 pub fn get_full_path(path: &std::path::PathBuf) -> Result<std::path::PathBuf, io::Error> {
     dunce::canonicalize(path)
 }
+/// Gets the absolute path of path without checking if the path actually exists
+pub fn get_absolute_path(path: &std::path::PathBuf) -> Result<std::path::PathBuf, io::Error> {
+    std::path::absolute(path)
+}
 
 pub fn current_folder() -> Result<std::path::PathBuf, io::Error> {
     std::env::current_dir()

--- a/src/core/file_utils/file_utils.rs
+++ b/src/core/file_utils/file_utils.rs
@@ -31,8 +31,10 @@ pub fn list_dir_files(dir: &std::path::PathBuf) -> Result<Vec<std::path::PathBuf
         .collect())
 }
 
-// From https://stackoverflow.com/a/38384901
+/// Gets the absolute path of path
+/// This function checks if the file exists
 pub fn get_full_path(path: &std::path::PathBuf) -> Result<std::path::PathBuf, io::Error> {
+    // From https://stackoverflow.com/a/38384901
     dunce::canonicalize(path)
 }
 /// Gets the absolute path of path without checking if the path actually exists


### PR DESCRIPTION
This PR refactors existing compiler code so we can easily add new compiler types